### PR TITLE
Fix for | CVE-2025-22228: BCrypt password length | Version 6.1

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -611,6 +611,10 @@ public class BCrypt {
 		int rounds, off;
 		StringBuilder rs = new StringBuilder();
 
+		// Enforce max length for new passwords only
+		if (!for_check && passwordb.length > 72) {
+			throw new IllegalArgumentException("password cannot be more than 72 bytes");
+		}
 		if (salt == null) {
 			throw new IllegalArgumentException("salt cannot be null");
 		}

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -611,9 +611,13 @@ public class BCrypt {
 		int rounds, off;
 		StringBuilder rs = new StringBuilder();
 
-		// Enforce max length for new passwords only
-		if (!for_check && passwordb.length > 72) {
-			throw new IllegalArgumentException("password cannot be more than 72 bytes");
+		if (passwordb.length > 72) {
+			if(!for_check){
+				throw new IllegalArgumentException("Password too long: New passwords must not exceed 72 characters, as only the first 72 characters are securely hashed. Please choose a shorter password.");
+			}
+			else{
+				throw new IllegalArgumentException("Password rejected: This password exceeds 72 characters. While it may be correct, we cannot verify it securely due to limitations in the previous hashing method. Please reset your password to ensure continued account security.");
+			}
 		}
 		if (salt == null) {
 			throw new IllegalArgumentException("salt cannot be null");

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
@@ -218,8 +218,39 @@ public class BCryptPasswordEncoderTests {
 	public void checkWhenNoRoundsThenTrue() {
 		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 		assertThat(encoder.matches("password", "$2a$00$9N8N35BVs5TLqGL3pspAte5OWWA2a2aZIs.EGp7At7txYakFERMue"))
-			.isTrue();
+				.isTrue();
 		assertThat(encoder.matches("wrong", "$2a$00$9N8N35BVs5TLqGL3pspAte5OWWA2a2aZIs.EGp7At7txYakFERMue")).isFalse();
+	}
+
+	@Test
+	public void encodeWhenPasswordOverMaxLengthThenThrowIllegalArgumentException() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password72chars = "123456789012345678901234567890123456789012345678901234567890123456789012";
+		encoder.encode(password72chars);
+
+		String password73chars = password72chars + "3";
+		assertThatIllegalArgumentException().isThrownBy(() -> encoder.encode(password73chars));
+	}
+
+	@Test
+	public void matchesWhenPasswordOverMaxLengthThenAllowToMatch() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password71chars = "12345678901234567890123456789012345678901234567890123456789012345678901";
+		String encodedPassword71chars = "$2a$10$jx3x2FaF.iX5QZ9i3O424Os2Ou5P5JrnedmWYHuDyX8JKA4Unp4xq";
+		assertThat(encoder.matches(password71chars, encodedPassword71chars)).isTrue();
+
+		String password72chars = password71chars + "2";
+		String encodedPassword72chars = "$2a$10$oXYO6/UvbsH5rQEraBkl6uheccBqdB3n.RaWbrimog9hS2GX4lo/O";
+		assertThat(encoder.matches(password72chars, encodedPassword72chars)).isTrue();
+
+		// Max length is 72 bytes, however, we need to ensure backwards compatibility
+		// for previously encoded passwords that are greater than 72 bytes and allow the
+		// match to be performed.
+		String password73chars = password72chars + "3";
+		String encodedPassword73chars = "$2a$10$1l9.kvQTsqNLiCYFqmKtQOHkp.BrgIrwsnTzWo9jdbQRbuBYQ/AVK";
+		assertThat(encoder.matches(password73chars, encodedPassword73chars)).isTrue();
 	}
 
 }

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
@@ -250,7 +250,7 @@ public class BCryptPasswordEncoderTests {
 		// match to be performed.
 		String password73chars = password72chars + "3";
 		String encodedPassword73chars = "$2a$10$1l9.kvQTsqNLiCYFqmKtQOHkp.BrgIrwsnTzWo9jdbQRbuBYQ/AVK";
-		assertThat(encoder.matches(password73chars, encodedPassword73chars)).isTrue();
+		assertThatIllegalArgumentException().isThrownBy(() -> encoder.matches(password73chars, encodedPassword73chars));
 	}
 
 }


### PR DESCRIPTION
Added limit on the new password creation to be at max 72 characters, without breaking the previous passwords avoiding the timing attack mitigation problem

- New password creation --> Exception when password length > 72
- Existing password --> No exception while checking the password even if length > 72