### PR TITLE
Fix for | CVE-2025-22228: BCrypt password length | Version 5.0

### DIFF
--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -497,12 +497,27 @@ public class BCrypt {
 	 * @param log_rounds the binary logarithm of the number of rounds of hashing to apply
 	 * @return an array containing the binary hashed password
 	 */
-	private byte[] crypt_raw(byte password[], byte salt[], int log_rounds) {
+	private byte[] crypt_raw(byte password[], byte salt[], int log_rounds, boolean for_check) {
 		int cdata[] = (int[]) bf_crypt_ciphertext.clone();
 		int clen = cdata.length;
 		byte ret[];
 
-		long rounds = roundsForLogRounds(log_rounds);
+		long rounds;
+		if(log_rounds<4 ||log_rounds>31){
+			if(!for_check){
+				throw new IllegalArgumentException("Bad number of rounds");
+			}
+			if (log_rounds != 0) {
+				throw new IllegalArgumentException("Bad number of rounds");
+			}
+			rounds = 0;
+		}
+		else{
+			rounds = roundsForLogRounds(log_rounds);
+			if (rounds < 16 || rounds > 2147483648L) {
+				throw new IllegalArgumentException("Bad number of rounds");
+			}
+		}
 
 		init_key();
 		ekskey(salt, password);
@@ -527,6 +542,10 @@ public class BCrypt {
 		return ret;
 	}
 
+	public static String hashpw(String password, String salt){
+		return hashpw(password, salt, false);
+	}
+
 	/**
 	 * Hash a password using the OpenBSD bcrypt scheme
 	 * @param password the password to hash
@@ -534,7 +553,7 @@ public class BCrypt {
 	 * @return the hashed password
 	 * @throws IllegalArgumentException if invalid salt is passed
 	 */
-	public static String hashpw(String password, String salt) throws IllegalArgumentException {
+	public static String hashpw(String password, String salt, boolean for_check) throws IllegalArgumentException {
 		BCrypt B;
 		String real_salt;
 		byte passwordb[], saltb[], hashed[];
@@ -579,6 +598,16 @@ public class BCrypt {
 		real_salt = salt.substring(off + 3, off + 25);
 		try {
 			passwordb = (password + (minor >= 'a' ? "\000" : "")).getBytes("UTF-8");
+			if (passwordb.length > 72) {
+				if (!for_check) {
+					throw new IllegalArgumentException(
+						"Password too long: New passwords must not exceed 72 characters, as only the first 72 characters are securely hashed. Please choose a shorter password.");
+				}
+				else {
+					throw new IllegalArgumentException(
+						"Password rejected: This password exceeds 72 characters. While it may be correct, we cannot verify it securely due to limitations in the previous hashing method. Please reset your password to ensure continued account security.");
+				}
+			}
 		}
 		catch (UnsupportedEncodingException uee) {
 			throw new AssertionError("UTF-8 is not supported");
@@ -587,7 +616,7 @@ public class BCrypt {
 		saltb = decode_base64(real_salt, BCRYPT_SALT_LEN);
 
 		B = new BCrypt();
-		hashed = B.crypt_raw(passwordb, saltb, rounds);
+		hashed = B.crypt_raw(passwordb, saltb, rounds, for_check);
 
 		rs.append("$2");
 		if (minor >= 'a') {

--- a/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
+++ b/crypto/src/main/java/org/springframework/security/crypto/bcrypt/BCrypt.java
@@ -542,6 +542,10 @@ public class BCrypt {
 		return ret;
 	}
 
+	public static String hashpwForCheck(String password, String salt){
+		return hashpw(password, salt, true);
+	}
+
 	public static String hashpw(String password, String salt){
 		return hashpw(password, salt, false);
 	}
@@ -685,7 +689,7 @@ public class BCrypt {
 	 * @return true if the passwords match, false otherwise
 	 */
 	public static boolean checkpw(String plaintext, String hashed) {
-		return equalsNoEarlyReturn(hashed, hashpw(plaintext, hashed));
+		return equalsNoEarlyReturn(hashed, hashpwForCheck(plaintext, hashed));
 	}
 
 	static boolean equalsNoEarlyReturn(String a, String b) {

--- a/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
+++ b/crypto/src/test/java/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoderTests.java
@@ -103,4 +103,35 @@ public class BCryptPasswordEncoderTests {
 		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 		encoder.matches(null, "does-not-matter");
 	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void encodeWhenPasswordOverMaxLengthThenThrowIllegalArgumentException() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password72chars = "123456789012345678901234567890123456789012345678901234567890123456789012";
+		encoder.encode(password72chars);
+
+		String password73chars = password72chars + "3";
+		encoder.encode(password73chars);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void matchesWhenPasswordOverMaxLengthThenAllowToMatch() {
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+		String password71chars = "12345678901234567890123456789012345678901234567890123456789012345678901";
+		String encodedPassword71chars = "$2a$10$jx3x2FaF.iX5QZ9i3O424Os2Ou5P5JrnedmWYHuDyX8JKA4Unp4xq";
+		assertThat(encoder.matches(password71chars, encodedPassword71chars)).isTrue();
+
+		String password72chars = password71chars + "2";
+		String encodedPassword72chars = "$2a$10$oXYO6/UvbsH5rQEraBkl6uheccBqdB3n.RaWbrimog9hS2GX4lo/O";
+		assertThat(encoder.matches(password72chars, encodedPassword72chars)).isTrue();
+
+		// Max length is 72 bytes, however, we need to ensure backwards compatibility
+		// for previously encoded passwords that are greater than 72 bytes and allow the
+		// match to be performed.
+		String password73chars = password72chars + "3";
+		String encodedPassword73chars = "$2a$10$1l9.kvQTsqNLiCYFqmKtQOHkp.BrgIrwsnTzWo9jdbQRbuBYQ/AVK";
+		encoder.matches(password73chars, encodedPassword73chars);
+	}
 }


### PR DESCRIPTION
Added limit on the new password creation to be at max 72 characters, without breaking the previous passwords avoiding the timing attack mitigation problem

New password creation --> Exception when password length > 72
Existing password --> No exception while checking the password even if length > 72
Added for check method entirely since it was introduced in versions 5.5+

Additionally there were build configurations updates 